### PR TITLE
Fix module name conflict with FMS in UFS

### DIFF
--- a/CCTM/src/aero/aero6/aero_depv.F
+++ b/CCTM/src/aero/aero6/aero_depv.F
@@ -87,7 +87,7 @@ C-----------------------------------------------------------------------
       USE UTILIO_DEFN      
       USE AERO_DATA           ! aero variable data
       USE AEROMET_DATA        ! Includes CONST.EXT
-      USE Mosaic_Mod, Only: ADEPVJ  ! Shared mosaic variables
+      USE MOSAIC_MODS, Only: ADEPVJ  ! Shared mosaic variables
       Use LSM_Mod, Only: N_LUFRAC
       USE ASX_DATA_MOD, Only: Met_Data
 

--- a/CCTM/src/depv/m3dry/ABFLUX_MOD.F
+++ b/CCTM/src/depv/m3dry/ABFLUX_MOD.F
@@ -522,7 +522,7 @@ C-------------------------------------------------------------------------------
          Use UTILIO_DEFN
          Use Bidi_Mod, Only: gamma1, gamma2, MHp1, MHp2
          Use ASX_DATA_MOD
-         Use Mosaic_Mod
+         Use MOSAIC_MODS
          Use LSM_MOD
          
          Implicit None

--- a/CCTM/src/depv/m3dry/DEPV_DEFN.F
+++ b/CCTM/src/depv/m3dry/DEPV_DEFN.F
@@ -671,7 +671,7 @@ C-----------------------------------------------------------------------
          USE CGRID_SPCS          ! CGRID mechanism species
          USE DEPVVARS
          USE UTILIO_DEFN
-         USE Mosaic_Mod
+         USE MOSAIC_MODS
          USE Bidi_Mod, Only: HgBidi
          USE LSM_Mod,  Only: n_lufrac
          USE ASX_DATA_MOD, Only: GRID_DATA, MOSAIC_DATA

--- a/CCTM/src/depv/m3dry/DEPV_DEFN.F
+++ b/CCTM/src/depv/m3dry/DEPV_DEFN.F
@@ -148,7 +148,7 @@ C-----------------------------------------------------------------------
          USE CGRID_SPCS          ! CGRID mechanism species
          USE DEPVVARS
          USE UTILIO_DEFN
-         USE MOSAIC_MOD, Only: Init_Mosaic
+         USE MOSAIC_MODS, Only: Init_Mosaic
          USE LSM_MOD, Only: Init_LSM, n_lufrac
          USE BIDI_MOD, Only: Init_Bidi, HgBidi
 

--- a/CCTM/src/depv/m3dry/MOSAIC_MOD.F
+++ b/CCTM/src/depv/m3dry/MOSAIC_MOD.F
@@ -22,7 +22,7 @@ C RCS file, release, date & time of last delta, author, state, [and locker]
 C $Header: /project/work/rep/arc/CCTM/src/depv/m3dry/MOSAIC_MOD.F,v 1.6 2012/03/28 16:11:09 yoj Exp $
 
 c:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-      Module MOSAIC_MOD
+      Module MOSAIC_MODS
       
 C Contains the shared variables and subrountes needed estimated the resistances
 C from natural and agricultrual lands for NH3 bidirectional flux
@@ -587,4 +587,4 @@ C local volatile variable
          Return
          End Subroutine RA_WRF
       
-      End Module Mosaic_Mod
+      End Module MOSAIC_MODS

--- a/CCTM/src/depv/m3dry/m3dry.F
+++ b/CCTM/src/depv/m3dry/m3dry.F
@@ -157,7 +157,7 @@ C-------------------------------------------------------------------------------
 #endif     
       Use ABFlux_Mod     ! bidi NH3 exchange routines
       Use LSM_Mod        ! land surface model variables needed for mosaic and bidi
-      Use Mosaic_Mod     ! contains mosaic routines
+      Use MOSAIC_MODS     ! contains mosaic routines
       Use ASX_DATA_MOD   ! contains CONSTANTS include
       Use BIDI_MOD, only:HGBIDI    ! contains CONSTANTS include
       Use HGSIM


### PR DESCRIPTION
Change Module_MOD or MODULE_MOD to Module_Mods and MODULE_MODS to fix an issue with module name conflict happening with FMS and their module_mod.

Tested on WCOSS2, Orion, Cheyenne.gnu/intel



